### PR TITLE
Simplify `_is_atomic` to use single isinstance call

### DIFF
--- a/ordered_set/__init__.py
+++ b/ordered_set/__init__.py
@@ -49,7 +49,7 @@ def _is_atomic(obj: Any) -> bool:
     OrderedSet of strings. It shouldn't give the indexes of each individual
     character.
     """
-    return isinstance(obj, str) or isinstance(obj, tuple)
+    return isinstance(obj, (str, tuple))
 
 
 class OrderedSet(MutableSet[T], Sequence[T]):


### PR DESCRIPTION
When you want to check whether something is one of multiple different types, you can merge the two isinstance checks into a single call.

This is shorter while staying nice and easy to read.