### PR TITLE
Use f-strings instead of legacy formatting style

### DIFF
--- a/ordered_set/__init__.py
+++ b/ordered_set/__init__.py
@@ -215,9 +215,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
             for item in sequence:
                 item_index = self.add(item)
         except TypeError:
-            raise ValueError(
-                "Argument needs to be an iterable, got %s" % type(sequence)
-            )
+            raise ValueError(f"Argument needs to be an iterable, got {type(sequence}")
         return item_index
 
     @overload
@@ -319,8 +317,8 @@ class OrderedSet(MutableSet[T], Sequence[T]):
 
     def __repr__(self) -> str:
         if not self:
-            return "%s()" % (self.__class__.__name__,)
-        return "%s(%r)" % (self.__class__.__name__, list(self))
+            return f"{self.__class__.__name__}()"
+        return f"{self.__class__.__name__}({list(self)!r})"
 
     def __eq__(self, other: Any) -> bool:
         """


### PR DESCRIPTION
The [Python documentation](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) notes that using the `%` operator to format strings can lead to 'a variety of quirks that lead to a number of common errors'.

Python added f-strings in version 3.6, with PEP 498. F-strings are a flexible and powerful way to format strings. They make the code shorter and more readable, since the code now looks more like the output.

These are also performance benefits to using f-strings as they require the interpreter to only parse the string once rather than backtracking for insertions, requiring multiple parses of the string.

As this library only supports Python 3.7+, there is no compatibility concerns.
https://github.com/rspeer/ordered-set/blob/master/pyproject.toml#L24