### PR TITLE
Make T covariant

### DIFF
--- a/ordered_set/__init__.py
+++ b/ordered_set/__init__.py
@@ -22,10 +22,10 @@ from typing import (
 )
 
 SLICE_ALL = slice(None)
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 
-T = TypeVar("T")
+T = TypeVar("T", covariant=True)
 
 # SetLike[T] is either a set of elements of type T, or a sequence, which
 # we will convert to an OrderedSet by adding its elements in order.


### PR DESCRIPTION
The containers from typing are covariant in their args. It'd make sense to make OrderedSet covariant too.

```
from ordered_set import OrderedSet

class A:
    pass

class B(A):
    pass

def my_fun(things: OrderedSet[A]) -> None:
    pass

things1 = OrderedSet([A()])
things2 = OrderedSet([B()])

my_fun(things1) # ok
my_fun(things2) # Argument 1 to "my_fun" has incompatible type "OrderedSet[B]"; expected "OrderedSet[A]"  [arg-type]

# Workaround:

from typing import cast

my_fun(cast(OrderedSet[A], things2))
```