### PR TITLE
Smooth out redundant lists

### DIFF
--- a/ordered_set/__init__.py
+++ b/ordered_set/__init__.py
@@ -365,8 +365,7 @@ class OrderedSet(MutableSet[T], Sequence[T]):
         cls: type = OrderedSet
         if isinstance(self, OrderedSet):
             cls = self.__class__
-        containers = map(list, it.chain([self], sets))
-        items = it.chain.from_iterable(containers)
+        items = itertools.chain(self, *sets)
         return cls(items)
 
     def __and__(self, other: SetLike[T]) -> "OrderedSet[T]":


### PR DESCRIPTION
Removes unnecessary step that created nested lists, only for them to be flattened in the very next step, when the fully flattened lists can instead be instantiated in a single step, thus saving (subject to testing) perhaps 1-2% of the time on the entire .union() operation